### PR TITLE
Fix possible infinite loop

### DIFF
--- a/src/shamir.c
+++ b/src/shamir.c
@@ -76,7 +76,7 @@ int32_t split_secret(
         // just return share_count copies of the secret
         uint8_t *share = result;
         for(uint8_t i=0; i< share_count; ++i, share += secret_length) {
-            for(uint8_t j=0; j<secret_length; ++j) {
+            for (uint8_t j = 0; j < (uint8_t) secret_length; ++j) {
                 share[j] = secret[j];
             }
         }
@@ -139,7 +139,7 @@ int32_t recover_secret(
     uint8_t valid = 1;
 
     if(threshold == 1) {
-        for(uint8_t j=0; j<share_length; ++j) {
+        for (uint8_t j = 0; j < (uint8_t) share_length; ++j) {
             secret[j] = shares[0][j];
         }
         return share_length;


### PR DESCRIPTION
Hi,

I am not sure why the `share_length` and `secret_length` variables are defined as type `uint32_t` but both are being compared to a `uint8_t` in a loop condition. This causes CodeQL to give a high severity security warning. '*High Severity*' is probably a bit alarmist but in a loop condition, comparison of a value of a narrow type with a value of a wide type may result in unexpected behaviour if the wider value is sufficiently large (or small). This is because the narrower value may overflow. This can lead to an infinite loop.

See here for further explanation of the warning:
[Comparison of narrow type with wide type in loop condition](https://codeql.github.com/codeql-query-help/cpp/cpp-comparison-with-wider-type/)

This PR fixes #42 by casting `share_length` and `secret_length` to `uint8_t` ensuring comparison of same types. If type casting is not the solution then maybe `share_length` and `secret_length` should be declared as `uint8_t` not `uint32_t`?

Note: I chose to cast to the narrower `uint8_t` rather than declaring `j` as the wider `uint32_t` as I think neither `share_length` or `secret_length` *should* ever be bigger than 255.